### PR TITLE
Set log level to INFO and add logging tests

### DIFF
--- a/functions/manager.py
+++ b/functions/manager.py
@@ -808,8 +808,9 @@ def lambda_handler(
         command = event["command"]
         body = event["body"]
     except KeyError:
-        err_msg: Dict[str, str]
-        err_msg = _missing_required_keys(["command", "body"], list(event))
+        err_msg: Dict[str, str] = _missing_required_keys(
+            ["command", "body"], list(event)
+        )
         log(**err_msg)
         return err_msg
 

--- a/functions/manager.py
+++ b/functions/manager.py
@@ -280,8 +280,9 @@ def _generate_container_definition(
         if container_definition["name"] == container_name:
             break
     else:
-        log(container_definition)
-        raise KeyError(f"Definition for container {container_name} not found.")
+        msg = f"Definition for container {container_name} not found."
+        log(msg=msg, data=container_definition, level="critical")
+        raise KeyError(msg)
 
     container_definition["logConfiguration"]["options"][
         "awslogs-stream-prefix"
@@ -318,8 +319,10 @@ def _healthcheck(body: Dict[str, Union[str, None]]) -> Boto3Result:
         Boto3InputError: If cluster_id is not set or is not a string.
     """
     if not isinstance(body.get("cluster"), str):
-        err_msg = _missing_required_keys(["cluster"], list(body))
-        log(*err_msg)
+        err_msg: Dict[str, str] = _missing_required_keys(
+            ["cluster"], list(body)
+        )
+        log(**err_msg)
         return Boto3Result(exc=KeyError(err_msg))
 
     task_filters = {
@@ -471,7 +474,11 @@ def _runtask(body: Dict[str, Union[str, None]]) -> Boto3Result:
         if r.error:
             return r
         target_taskdef_arn = r.body["taskDefinition"]["taskDefinitionArn"]
-        log(msg="Created task definition", data=target_taskdef_arn)
+        log(
+            msg="Created task definition",
+            data=target_taskdef_arn,
+            level="info",
+        )
     else:
         target_taskdef_arn = svc_taskdef_arn
 
@@ -489,13 +496,17 @@ def _runtask(body: Dict[str, Union[str, None]]) -> Boto3Result:
     if r.error:
         return r
     new_task_arn = r.body["tasks"][0]["taskArn"]
-    log(msg="Running task", data=new_task_arn)
+    log(msg="Running task", data=new_task_arn, level="info")
 
     # wait for the task to finish
     r = _task_wait(ecs=ecs, cluster=_cluster, task_arn=new_task_arn)
     if r.error:
         return r
-    log(msg="Finished waiting for task execution", data=new_task_arn)
+    log(
+        msg="Finished waiting for task execution",
+        data=new_task_arn,
+        level="info",
+    )
 
     # inspect task result
     r = invoke(
@@ -656,10 +667,10 @@ def _deploy(body: Dict[str, Union[str, List[str]]]) -> Boto3Result:
     )
 
     if cluster_id is None or service_ids is None:
-        err_msg = _missing_required_keys(
+        err_msg: Dict[str, str] = _missing_required_keys(
             ["cluster_id", "service_ids"], list(body)
         )
-        log(*err_msg)
+        log(**err_msg)
         return Boto3Result(exc=KeyError(err_msg))
 
     if secrets and not isinstance(secrets, list):
@@ -739,6 +750,7 @@ def _deploy(body: Dict[str, Union[str, List[str]]]) -> Boto3Result:
                     "service_containerdefs": taskdef["containerDefinitions"],
                     "executionRoleArn": taskdef["executionRoleArn"],
                 },
+                level="info",
             )
 
             r = register_task_definition(ecs_client, taskdef)
@@ -746,8 +758,9 @@ def _deploy(body: Dict[str, Union[str, List[str]]]) -> Boto3Result:
                 return r
             else:
                 log(
-                    "Registered task definition",
-                    r.body["taskDefinition"]["taskDefinitionArn"],
+                    msg="Registered task definition",
+                    data=r.body["taskDefinition"]["taskDefinitionArn"],
+                    level="info",
                 )
 
         # if we registered a new task definition, 'r' is the response from the
@@ -765,7 +778,7 @@ def _deploy(body: Dict[str, Union[str, List[str]]]) -> Boto3Result:
             return r
         else:
             service_arn: str = r.body["service"]["serviceArn"]
-            log("Updated service", service_arn)
+            log(msg="Updated service", data=service_arn, level="info")
             updated_services.append(service_arn)
 
     success = {
@@ -805,13 +818,12 @@ def lambda_handler(
     """
     start_t = time.time()
     log(msg="event received", data=event, level="info")
+    err_msg: Dict[str, str]
     try:
         command = event["command"]
         body = event["body"]
     except KeyError:
-        err_msg: Dict[str, str] = _missing_required_keys(
-            ["command", "body"], list(event)
-        )
+        err_msg = _missing_required_keys(["command", "body"], list(event))
         log(**err_msg)
         return err_msg
 
@@ -819,13 +831,15 @@ def lambda_handler(
         err_msg = {
             "msg": f"Command not recognized: '{command}'.",
             "data": "Must be one of: {}".format(list(__DISPATCH__)),
+            "level": "critical",
         }
         log(**err_msg)
         return err_msg
     else:
         result = __DISPATCH__[command](body)  # type: ignore
-        response: Dict[str, Any]
-        response = {"request_payload": {"command": command, "body": body}}
+        response: Dict[str, Any] = {
+            "request_payload": {"command": command, "body": body}
+        }
         response.update(result.error or result.body)
 
     duration = "{} ms".format(round(1000 * (time.time() - start_t), 2))

--- a/functions/manager.py
+++ b/functions/manager.py
@@ -18,7 +18,7 @@ LOGGER = logging.getLogger()
 LOGGER_LEVEL = logging.INFO
 LOGGER.setLevel(LOGGER_LEVEL)
 STDOUT_HANDLER = logging.StreamHandler(sys.stdout)
-STDOUT_HANDLER.setLevel(logging.INFO)
+STDOUT_HANDLER.setLevel(LOGGER_LEVEL)
 LOGGER.addHandler(STDOUT_HANDLER)
 
 

--- a/functions/manager.py
+++ b/functions/manager.py
@@ -59,6 +59,7 @@ def _missing_required_keys(
             f"'{missing_keys}' field(s) not optional. "
             f"Found: {found_keys}.  Required: {required_keys}"
         ),
+        "level": "critical",
     }
 
 

--- a/functions/manager.py
+++ b/functions/manager.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Optional, Union, cast
 import boto3
 
 LOGGER = logging.getLogger()
-LOGGER_LEVEL = logging.WARN
+LOGGER_LEVEL = logging.INFO
 LOGGER.setLevel(LOGGER_LEVEL)
 STDOUT_HANDLER = logging.StreamHandler(sys.stdout)
 STDOUT_HANDLER.setLevel(logging.INFO)

--- a/tests/test_manager/test_lambda_handler.py
+++ b/tests/test_manager/test_lambda_handler.py
@@ -13,6 +13,7 @@ class TestLambdaHandler:
                     "msg": "Required field(s) not found",
                     "data": "'['command']' field(s) not optional. "
                     "Found: ['body'].  Required: ['command', 'body']",
+                    "level": "critical",
                 },
             ),
             (
@@ -21,6 +22,7 @@ class TestLambdaHandler:
                     "msg": "Required field(s) not found",
                     "data": "'['body']' field(s) not optional. "
                     "Found: ['command'].  Required: ['command', 'body']",
+                    "level": "critical",
                 },
             ),
             (
@@ -29,6 +31,7 @@ class TestLambdaHandler:
                     "msg": "Required field(s) not found",
                     "data": "'['command', 'body']' field(s) not optional. "
                     "Found: [].  Required: ['command', 'body']",
+                    "level": "critical",
                 },
             ),
             (
@@ -38,6 +41,7 @@ class TestLambdaHandler:
                     "data": "'['command', 'body']' field(s) not optional. "
                     "Found: ['wrongkey1', 'wrongkey2'].  "
                     "Required: ['command', 'body']",
+                    "level": "critical",
                 },
             ),
         ],

--- a/tests/test_manager/test_logging.py
+++ b/tests/test_manager/test_logging.py
@@ -23,7 +23,7 @@ def test_logger_level():
         ("critical", logging.CRITICAL, 1),
     ],
 )
-def test_log_levels(caplog, levelname, levelno, expected_log_count):
+def test_log_output_per_level(caplog, levelname, levelno, expected_log_count):
     msg = "logging message"
     data = "logging data"
     expected = _logging_message(msg=msg, data=data)

--- a/tests/test_manager/test_logging.py
+++ b/tests/test_manager/test_logging.py
@@ -1,0 +1,36 @@
+import json
+import logging
+
+import pytest as _pytest
+
+import functions.manager as manager
+
+
+def _logging_message(msg="", data=None):
+    return json.dumps({"message": msg, "data": data}, default=str)
+
+
+def test_logger_level():
+    assert manager.LOGGER.getEffectiveLevel() == logging.INFO
+
+
+@_pytest.mark.parametrize(
+    ("levelname", "levelno", "expected_log_count"),
+    [
+        ("debug", logging.DEBUG, 0),
+        ("info", logging.INFO, 1),
+        ("warning", logging.WARNING, 1),
+        ("critical", logging.CRITICAL, 1),
+    ],
+)
+def test_log_levels(caplog, levelname, levelno, expected_log_count):
+    msg = "logging message"
+    data = "logging data"
+    expected = _logging_message(msg=msg, data=data)
+
+    manager.log(msg=msg, data=data, level=levelname)
+
+    assert len(caplog.records) == expected_log_count
+    if expected_log_count:
+        assert caplog.records[0].message == expected
+        assert caplog.records[0].levelno == levelno


### PR DESCRIPTION
EASI-646 / EASI-657

Changes proposed in this pull request:

* Set the logging level to INFO
* Ensure the same log level is used for the `sys.stdout` handler
* Test that INFO, WARNING, and CRITICAL messages are logged, but DEBUG are not