### PR TITLE
Remove SSM parameters input in terraform

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: check-useless-excludes
 
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.1.0
     hooks:
       - id: end-of-file-fixer
       - id: mixed-line-ending
@@ -58,7 +58,7 @@ repos:
         types: [python]
 
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.1.0
+    rev: v2.2.0
     hooks:
       - id: seed-isort-config
 
@@ -68,12 +68,12 @@ repos:
       - id: shell-lint
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.22.0
+    rev: v0.23.2
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.27.0
+    rev: v1.31.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ module "lambda_ecs_manager" {
 
   app_name    = var.app_name
   environment = var.environment
-  parameters = ["arn:aws:ssm:us-east-2:123456789012:parameter/prod-*"]
 
   task_role_arns           = [module.ecs_service_app.task_role_arn]
   task_execution_role_arns = [module.ecs_service_app.task_execution_role_arn]
@@ -41,7 +40,6 @@ No requirements.
 | app\_name | Name of the application the Lambda is associated with. | `string` | n/a | yes |
 | environment | Name of the environment the Lambda is deployed into. | `string` | n/a | yes |
 | logs\_retention | Number of days to retain lambda events. | `string` | `"365"` | no |
-| parameters | SSM Parameters the Lambda should be able to describe. | `list(string)` | `[]` | no |
 | publish | Whether to publish creation/change as new Lambda Function Version. | `bool` | `false` | no |
 | task\_execution\_role\_arns | ARN of the task execution role the Amazon ECS container agent and Docker daemon can assume. | `list(string)` | n/a | yes |
 | task\_role\_arns | ARNs of the IAM roles assumed by Amazon ECS container tasks. | `list(string)` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 /**
- * Creates a Lambda to manage ECS services in fargate.
+ * Creates a Lambda to manage ECS services in Fargate.
  *
  * Creates the following resources:
  *
@@ -15,7 +15,6 @@
  *
  *   app_name    = var.app_name
  *   environment = var.environment
- *   parameters = ["arn:aws:ssm:us-east-2:123456789012:parameter/prod-*"]
  *
  *   task_role_arns           = [module.ecs_service_app.task_role_arn]
  *   task_execution_role_arns = [module.ecs_service_app.task_execution_role_arn]
@@ -88,26 +87,20 @@ data "aws_iam_policy_document" "main" {
   #   https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-supported-iam-actions-resources.html
   statement {
     actions = [
-      "ecs:DescribeTasks",
       "ecs:DescribeServices",
       "ecs:DescribeTaskDefinition",
+      "ecs:DescribeTasks",
       "ecs:RegisterTaskDefinition",
       "ecs:RunTask",
       "ecs:UpdateService",
+      "ssm:DescribeParameters",
+      "ssm:GetParameters",
+      "ssm:ListTagsForResource",
     ]
 
     resources = ["*"]
   }
 
-  statement {
-    actions = [
-      "ssm:GetParameters",
-      "ssm:DescribeParameters",
-      "ssm:ListTagsForResource",
-    ]
-
-    resources = var.parameters
-  }
 }
 
 resource "aws_iam_role_policy" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -29,9 +29,3 @@ variable "publish" {
   description = "Whether to publish creation/change as new Lambda Function Version."
   default     = false
 }
-
-variable "parameters" {
-  type        = list(string)
-  description = "SSM Parameters the Lambda should be able to describe."
-  default     = []
-}


### PR DESCRIPTION
* `pre-commit autoupdate`
* Remove the SSM `parameters` input from the terraform code.

If the user passes anything except `*` here then the SSM process will
die with an unhandled exception, because the SSM client methods the
lambda uses currently will describe _all_ parameters before applying a
filter.