### PR TITLE
Use message body to determine which ECS task to run in ecs-manager

### DIFF
--- a/functions/manager.py
+++ b/functions/manager.py
@@ -433,7 +433,14 @@ def _runtask(body: Dict[str, Union[str, None]]) -> Boto3Result:
     Returns:
         Boto3Result
     """
-    taskdef_entrypoint: Optional[str] = body.get("entrypoint")
+    taskdef_entrypoint: str = body.get("entrypoint") or ""
+    if not isinstance(taskdef_entrypoint, str):
+        err_msg = {
+            "msg": "TypeError",
+            "data": "'entrypoint' key must be of type string",
+        }
+        log(**err_msg)
+        return Boto3Result(exc=TypeError(err_msg))
 
     missing_required_keys: List[Optional[str]] = []
     required_keys = {"container_id", "service_id", "cluster_id"}

--- a/functions/manager.py
+++ b/functions/manager.py
@@ -435,8 +435,6 @@ def _runtask(body: Dict[str, Union[str, None]]) -> Boto3Result:
     """
     taskdef_entrypoint: Optional[str] = body.get("entrypoint")
 
-    _environment = os.environ["ENVIRONMENT"]
-
     missing_required_keys: List[Optional[str]] = []
     required_keys = {"container_id", "service_id", "cluster_id"}
     validated = {
@@ -455,8 +453,6 @@ def _runtask(body: Dict[str, Union[str, None]]) -> Boto3Result:
     container_id = validated["container_id"]
     service_id = validated["service_id"]
     cluster_id = validated["cluster_id"]
-
-    taskdef_family = f"{service_id}-{_environment}"
 
     ecs = boto3.client("ecs")
 
@@ -477,6 +473,7 @@ def _runtask(body: Dict[str, Union[str, None]]) -> Boto3Result:
         if r.error:
             return r
         service_taskdef = r.body["taskDefinition"]
+        taskdef_family = service_taskdef["family"]
 
         # create and register a custom task definition by modifying the
         # existing service

--- a/main.tf
+++ b/main.tf
@@ -23,9 +23,7 @@
  */
 
 locals {
-  service_name   = "ecs-manager-${var.app_name}-${var.environment}"
-  log_group      = "/aws/lambda/${var.app_name}"
-  taskdef_family = "${var.app_name}-lambda-${var.environment}"
+  log_group = "/aws/lambda/${var.app_name}"
 }
 
 #
@@ -59,7 +57,7 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 }
 
 resource "aws_iam_role" "main" {
-  description        = "Allows Lambda functions to update ${local.taskdef_family} service container definitions."
+  description        = "Allows Lambda functions to update ECS services."
   name               = "lambda-${var.app_name}-${var.environment}"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }

--- a/main.tf
+++ b/main.tf
@@ -135,12 +135,6 @@ resource "aws_lambda_function" "main" {
   timeout          = 120
   publish          = var.publish
 
-  environment {
-    variables = {
-      ENVIRONMENT = var.environment
-    }
-  }
-
   tags = {
     Environment = var.environment
     Automation  = "Terraform"

--- a/main.tf
+++ b/main.tf
@@ -137,8 +137,6 @@ resource "aws_lambda_function" "main" {
 
   environment {
     variables = {
-      ECS_CLUSTER = var.environment
-      ECS_SERVICE = var.app_name
       ENVIRONMENT = var.environment
     }
   }

--- a/tests/test_manager/test_runtask.py
+++ b/tests/test_manager/test_runtask.py
@@ -1,4 +1,12 @@
+import itertools
+
+import pytest as _pytest
+
 import functions.manager as manager
+from functions.manager import Boto3Result as Boto3Result
+
+required_keys = ["container_id", "service_id", "cluster_id"]
+required_keys_combinations = itertools.combinations(required_keys, 2)
 
 
 class TestValidations:
@@ -8,3 +16,17 @@ class TestValidations:
         assert isinstance(result.exc, TypeError)
         assert result.error is not None
         assert result.body == {}
+
+    @_pytest.mark.parametrize(
+        ("body"),
+        [
+            {combo[0]: "foo", combo[1]: "bar"}
+            for combo in required_keys_combinations
+        ],
+    )
+    def test_required_keys_present(mock_invoke, body):
+        return
+        result = manager._runtask(body)
+
+        assert isinstance(result, Boto3Result)
+        assert result.exc == KeyError(manager._missing_required_keys())

--- a/tests/test_manager/test_runtask.py
+++ b/tests/test_manager/test_runtask.py
@@ -25,7 +25,6 @@ class TestValidations:
         ],
     )
     def test_required_keys_present(mock_invoke, body):
-        return
         result = manager._runtask(body)
 
         assert isinstance(result, Boto3Result)

--- a/tests/test_manager/test_runtask.py
+++ b/tests/test_manager/test_runtask.py
@@ -1,0 +1,10 @@
+import functions.manager as manager
+
+
+class TestValidations:
+    def test_entrypoint_type(mock_invoke):
+        result = manager._runtask({"entrypoint": [1, 2, 3]})
+
+        assert isinstance(result.exc, TypeError)
+        assert result.error is not None
+        assert result.body == {}


### PR DESCRIPTION
[EASI-686](https://jiraent.cms.gov/browse/EASI-686)

* Read cluster, service, and container ids from runtask body rather than local  env vars
* Rename some variables to match naming scheme used in other commands (e.g. `_container_name` -> `container_id`)
* Add basic tests for input validations
* Remove cluster, service, and environment env vars from Terraform code
* Remove some unused or useless locals from Terraform code