### PR TITLE
Don't read the container_id without entrypoint

### DIFF
--- a/functions/manager.py
+++ b/functions/manager.py
@@ -470,7 +470,6 @@ def _runtask(body: Dict[str, Union[str, None]]) -> Boto3Result:
         log(**err_msg)
         return Boto3Result(exc=KeyError(err_msg))
 
-    container_id = validated["container_id"]
     service_id = validated["service_id"]
     cluster_id = validated["cluster_id"]
 
@@ -486,6 +485,8 @@ def _runtask(body: Dict[str, Union[str, None]]) -> Boto3Result:
     svc_taskdef_arn = r.body["services"][0]["taskDefinition"]
 
     if taskdef_entrypoint:
+        container_id: str = body.get("container_id") or ""
+
         r = invoke(
             ecs.describe_task_definition, **{"taskDefinition": svc_taskdef_arn}
         )


### PR DESCRIPTION
This fixes a bug where an unhandled KeyError would occur whenever a container_id was not given. This key is not required unless an entrypoint is also given.