### PR TITLE
Replace circleci docker primary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   lint_and_test_python:
     docker:
-      - image: trussworks/circleci-docker-primary:540071e99807185ec96d01240a3926da5da18457
+      - image: trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
     steps:
       - checkout
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .envrc.local
+.mypy_cache/*
+functions.egginfo/*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # terraform-aws-lambda-ecs-manager
 
+## Terraform Versions
+
+Terraform 0.13. Pin module version to `~> 2.X`. Submit pull-requests to `master` branch.
+
+Terraform 0.12. Pin module version to `~> 1.X`. Submit pull-requests to `terraform012` branch.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 Creates a Lambda to manage ECS services in Fargate.
 
 Creates the following resources:
@@ -21,14 +28,6 @@ module "lambda_ecs_manager" {
   task_execution_role_arns = [module.ecs_service_app.task_execution_role_arn]
 }
 ```
-
-## Terraform Versions
-
-Terraform 0.13. Pin module version to `~> 2.X`. Submit pull-requests to `master` branch.
-
-Terraform 0.12. Pin module version to `~> 1.X`. Submit pull-requests to `terraform012` branch.
-
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -70,3 +70,156 @@ Terraform 0.12. Pin module version to `~> 1.X`. Submit pull-requests to `terrafo
 | version | Published version of the lambda function. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Invoking the lambda
+
+You can invoke the deployed ecs-manager lambda using aws-cli and the
+`environment` input you used when importing the module:
+
+```console
+aws lambda invoke --function-name "<environment>-ecs-manager" --payload payload.json output.json
+```
+
+### Get a status report on tasks
+
+ecs-manager can produce a report on the status of running and stopped tasks
+from a given service and/or task definition family:
+
+```json
+{
+    "command": "healthcheck",
+    "body": {
+        "cluster_id": "app-cluster",
+        "service_name": "app-service1"
+}
+```
+
+To find if any containers are unhealthy, exited non-zero, or reported any
+failures, this `jq` query can help:
+
+```console
+jq '.data.response.message.tasks |
+    any(
+        (.failures | length > 0)
+        or (
+            .containers | any(.exitCode > 0 or .healthStatus == "UNHEALTHY")
+        )
+    )' < output.json
+```
+
+It will print a boolean indicating if errors were found: `false` means the
+queried services' statuses are OK, while `true` means at least one problem was
+found.
+
+### Deploy an image
+
+To deploy a new image into each of the containers in a list of services:
+
+```json
+{
+    "command": "deploy",
+    "body": {
+        "cluster_id": "app-cluster",
+        "service_ids": ["app-service1", "app-service2"],
+        "image": "repo.url/app-service:test"
+    }
+}
+```
+
+This will find the services "app-service1" and "app-service2" in "app-cluster",
+registering new task definitions for each service with _all_ the images in each
+container definition set to `repo.url/app-service:test`. It then restarts the
+services.
+
+If the "image" key is omitted, services will be restarted in-place without any changes
+to the task definition:
+
+```json
+{
+    "command": "deploy",
+    "body": {
+        "cluster_id": "app-cluster",
+        "service_ids": ["app-service1", "app-service2"]
+    }
+}
+```
+
+#### SSM Parameters
+
+ecs-manager can add (or remove) secrets in an ECS task definition. Using the
+`secrets` key, pass in a list of regular expressions:
+
+```json
+{
+    "command": "deploy",
+    "body": {
+        "cluster_id": "app-cluster",
+        "service_ids": [
+            "app-service1"
+        ],
+        "secrets": [
+            "^/app-service1/secrets/\\S+$"
+        ]
+    }
+}
+```
+
+For each of the SSM Parameters with names that match any regular expression in the list,
+the `ENV_VAR_NAME` object tag will be read. If it is found, the Parameter's value
+will be added to the container definitions. For example, a Parameter with this tag:
+
+```console
+$ aws ssm list-tags-for-resource --resource-type "Parameter" --resource-id 'secrets/test'
+{
+    "TagList": [
+        {
+            "Key": "ENV_VAR_NAME",
+            "Value": "TEST"
+        }
+    ]
+}
+```
+
+Will appear in the task definition like so:
+
+```json
+"secrets": [
+    {
+        "name": "TEST",
+        "valueFrom": "secrets/test"
+    }
+]
+```
+
+For more information, see [Tagging SSM documents], and the [Amazon ECS Developer
+Guide] on _Specifying Sensitive Data Using Systems Manager Parameter Store_.
+
+[Tagging SSM Documents]: https://docs.aws.amazon.com/systems-manager/latest/userguide/tagging-documents.html
+[Amazon ECS Developer Guide]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-parameters.html
+
+## Development
+
+Set up the environment:
+
+```console
+brew install poetry pre-commit
+pre-commit install --install-hooks
+poetry install && poetry shell
+```
+
+To test the function locally:
+
+```console
+$ jq < payload.json  # run a task without changing the entryPoint in the task definition
+{
+  "command": "runtask",
+  "body": { "entrypoint": null }
+}
+$ ./run_local ./payload.json
+```
+
+To test the deployed Lambda:
+
+```console
+./invoke ./payload.json "function-name"
+```

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.13.0"
+
+  required_providers {
+    aws = "~> 3.0"
+  }
+}


### PR DESCRIPTION
# [Tracker story](https://www.pivotaltracker.com/story/show/174581758)

<!--
    Insert the tracker story URL in the markdown link above
    e.g., Fixes [#1324235](http://path/to/storyid/1324235)
--->

Changes proposed in this pull request:

- Replace `circleci-docker-primary` with `circleci` docker images
- Upgrade to terraform 13 since `circleci` is built with that version of TF
- Upgrade AWS provider to 3.0

## Checklist for Terraform changes

<!--
    - [x] a checked item
    - [ ] an unchecked item
-->

- [ ] Type `atlantis plan` as a Github comment to share your Terraform plan
- [ ] Get PR approval
- [ ] Type `atlantis apply`as a Github comment to apply and merge the plan

If the apply is successful, Atlantis will delete the branch and plan file.

---
<details><summary>Terraform plan</summary>

```terraform
Add Terraform plan here
```

</details>
