### PR TITLE
NextToken for DescribeParameters

### DIFF
--- a/functions/manager.py
+++ b/functions/manager.py
@@ -730,9 +730,14 @@ def _deploy(body: Dict[str, Union[str, List[str]]]) -> Boto3Result:
         next_token: str = " "
         ssm_parameters: List[Dict[str, Any]] = []
         while next_token:
+            describe_parameters_request = {
+                "MaxResults": 50,
+                "NextToken": next_token,
+            }
+            if next_token == " ":
+                describe_parameters_request = {"MaxResults": 50}
             r = invoke(
-                ssm_client.describe_parameters,
-                **{"MaxResults": 50, "NextToken": next_token},
+                ssm_client.describe_parameters, **describe_parameters_request,
             )
             if r.error:
                 return r


### PR DESCRIPTION
Passing " " as NextToken for the ssm describe_parameters call was generating the following error:

```
"botocore.errorfactory.InvalidNextToken: An error occurred (InvalidNextToken) when calling the DescribeParameters operation: The following token isn't valid:  ."
```

The cause appears to be a change introduced in:
boto3 1.15.17 / botocore 1.18.17

* https://github.com/boto/boto3/releases/tag/1.15.17
* https://github.com/boto/botocore/commit/f29d23c53ec0477e58450744986b0f8f23c97da1#diff-c90af15803344fad6bc2705093475d4ba300bd9967d7d2df6ed4212ca2ad7d44R2666
