### PR TITLE
AWS provider 3 updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: check-useless-excludes
 
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.3.0
     hooks:
       - id: end-of-file-fixer
       - id: mixed-line-ending
@@ -68,12 +68,12 @@ repos:
       - id: shell-lint
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.23.2
+    rev: v0.25.0
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.31.0
+    rev: v1.45.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt

--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ data "aws_iam_policy_document" "main" {
       "logs:PutLogEvents",
     ]
 
-    resources = [aws_cloudwatch_log_group.main.arn]
+    resources = ["${aws_cloudwatch_log_group.main.arn}:*"]
   }
 
   # allow the lambda to assume the task roles


### PR DESCRIPTION
* Modify the cloudwatch log group arn to address a breaking change in AWS provider 3.x that automatically trims the `:*` suffix from the cloudwatch log group arn.
* Update precommit to fix a terraform_docs issue.