### PR TITLE
Increase ECS Waiter limits to defaults

### DIFF
--- a/functions/manager.py
+++ b/functions/manager.py
@@ -590,8 +590,8 @@ def _task_wait(
     ecs: boto3.client,
     cluster: str,
     task_arn: str,
-    delay: int = 6,
-    attempts: int = 20,
+    delay: int = 15,
+    attempts: int = 40,
 ) -> Boto3Result:
     """Wait for a task to finish.
 


### PR DESCRIPTION
This should help reduce WaiterErrors that have been failing builds lately.