### PR TITLE
Use AWS linux python for base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3-buster
+FROM amazon/aws-lambda-python:3
 
 ARG MANAGER_VERSION="2.1.1"
 
 # Install build dependencies
-RUN pip3 install --disable-pip-version-check --progress-bar off 'poetry==1.1.4'
+RUN pip3 install --no-cache-dir --disable-pip-version-check --progress-bar off 'poetry==1.1.4'
 
 # Install ecs manager
 WORKDIR /home/
@@ -11,6 +11,6 @@ RUN curl --silent --show-error --location https://github.com/trussworks/terrafor
  && unzip manager.zip
 
 WORKDIR /home/terraform-aws-lambda-ecs-manager-"$MANAGER_VERSION"
-RUN poetry build && pip3 install --disable-pip-version-check dist/functions-"$MANAGER_VERSION"-py3-none-any.whl
+RUN poetry build && pip3 install --no-cache-dir --disable-pip-version-check dist/functions-"$MANAGER_VERSION"-py3-none-any.whl
 
 ENTRYPOINT ["python3", "-m", "functions.manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
 FROM amazon/aws-lambda-python:3
 
-ARG MANAGER_VERSION="2.1.1"
+ARG MANAGER_VERSION="2.1.2"
 
 # Install build dependencies
 RUN pip3 install --no-cache-dir --disable-pip-version-check --progress-bar off 'poetry==1.1.4'
 
 # Install ecs manager
 WORKDIR /home/
-RUN curl --silent --show-error --location https://github.com/trussworks/terraform-aws-lambda-ecs-manager/archive/"$MANAGER_VERSION".zip > manager.zip \
- && unzip manager.zip
+COPY . .
 
-WORKDIR /home/terraform-aws-lambda-ecs-manager-"$MANAGER_VERSION"
 RUN poetry build && pip3 install --no-cache-dir --disable-pip-version-check dist/functions-"$MANAGER_VERSION"-py3-none-any.whl
 
 ENTRYPOINT ["python3", "-m", "functions.manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ COPY . .
 
 RUN poetry build && pip3 install --no-cache-dir --disable-pip-version-check dist/functions-"$MANAGER_VERSION"-py3-none-any.whl
 
-CMD ["functions.manager"]
+CMD ["functions.manager.lambda_handler"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ COPY . .
 
 RUN poetry build && pip3 install --no-cache-dir --disable-pip-version-check dist/functions-"$MANAGER_VERSION"-py3-none-any.whl
 
-ENTRYPOINT ["python3", "-m", "functions.manager"]
+CMD ["functions.manager"]


### PR DESCRIPTION
It seems that bootstrap files required for Lambda aren't included in the debian based images. I was able to confirm that this works in the shell:

```
$ line 6: aws lambda invoke --qualifier '$LATEST' --cli-read-timeout 240 --function dev-ecs-manager-docker --cli-binary-format raw-in-base64-out --payload "" lambda_response.json
{
    "StatusCode": 200,
    "ExecutedVersion": "$LATEST"
}
$ jq < lambda_response.json
{
  "msg": "Required field(s) not found",
  "data": "'['command', 'body']' field(s) not optional. Found: [].  Required: ['command', 'body']",
  "level": "critical"
}