### PR TITLE
Bump version to 2.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazon/aws-lambda-python:3
 
-ARG MANAGER_VERSION="2.1.2"
+ARG MANAGER_VERSION="2.3.0"
 
 # Install build dependencies
 RUN pip3 install --no-cache-dir --disable-pip-version-check --progress-bar off 'poetry==1.1.4'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "functions"
-version = "2.1.2"
+version = "2.3.0"
 description = ""
 authors = ["Ryan Delaney <ryan@truss.works>"]
 readme = "README.md"


### PR DESCRIPTION
Bump the version to 2.3.0 in preparation for cutting a new release of the Terraform module.